### PR TITLE
Fix css issue scrolling related to iOS browser

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,6 +1,6 @@
 #root
 {
-  height: 100vh;
+  min-height: 100svh;
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/src/components/CalculationPanel/CalculationPanel.module.css
+++ b/src/components/CalculationPanel/CalculationPanel.module.css
@@ -6,7 +6,7 @@
   grid-template-columns: 1fr;
   grid-template-areas: "timer" "calculation";
   gap: 2rem;
-  margin-top: -10vh; 
+  transform: translateY(-15%);
  
   .calculation_container
   {


### PR DESCRIPTION
### **Issue**
When using app on iOS Safari browser, there will unwanted vertical scrolling bar


This issue happen because I used vh to set the height of page. However iOS treats vh differently where vh doesn't account for search bar.

### **Resolution**
Use `svh` instead