### PR TITLE
Update keyboard to use text

### DIFF
--- a/src/components/CalculationPanel/MainCalculationQuestion/MainCalculationQuestion.tsx
+++ b/src/components/CalculationPanel/MainCalculationQuestion/MainCalculationQuestion.tsx
@@ -31,6 +31,7 @@ function MainCalculationQuestion(prop: {expression: string, onAnswerEntered: (an
                     className={styles.answer_input}
                     type="text"
                     pattern="[0-9]*"
+                    inputMode="text"
                     maxLength={8}
                     ref={inputRef}
                     value={inputValue}


### PR DESCRIPTION
### Issue

There is no way of submitting on iOS device when input is number pad

### Resolution

Use inputMode text instead