### PR TITLE
Create Time Component

### DIFF
--- a/docs/developer.journal.md
+++ b/docs/developer.journal.md
@@ -1,0 +1,12 @@
+# Developer Journal
+### Dec 20, 2025
+#### Overview
+- Separated the timer into a `Timer` component to avoid `CalculationPanel` re-rendering every second due to the `useEffect` that updated `seconds`.
+
+#### Problem Encountered
+1. Wasn't sure how to update seconds without triggering a re-render in `CalculationPanel`.
+2. Wasn't sure of the cause of the stale-closure issue causing `onTick` to receive 0 seconds every time.
+
+#### Resolution
+1. Used `useRef` to store the updated timer value without triggering a re-render in `CalculationPanel`.
+2. The stale closure was caused by `useEffect` only running once due to the `[]` dependency. Resolved by separating into two `useEffect`s: one to update the timer, and a second to trigger `onTick` with `[seconds, onTick]` dependencies.

--- a/src/components/CalculationPanel/CalculationPanel.module.css
+++ b/src/components/CalculationPanel/CalculationPanel.module.css
@@ -14,18 +14,4 @@
 		align-items: center;
 		gap: 2rem;
 	}
-
-	.timer {
-		grid-area: timer;
-		display: flex;
-		flex-direction: row;
-		justify-content: center;
-		gap: 0.5rem;
-
-		font-weight: 500;
-
-		.time {
-			font-variant-numeric: tabular-nums;
-		}
-	}
 }

--- a/src/components/CalculationPanel/CalculationPanel.tsx
+++ b/src/components/CalculationPanel/CalculationPanel.tsx
@@ -1,6 +1,6 @@
 import { Navigate } from 'react-router-dom';
 
-import { type JSX, type RefObject, useCallback, useRef } from 'react';
+import { type JSX, useCallback, useRef } from 'react';
 
 import { type Question, type QuestionAnswer } from '../../assets/types';
 import paths from '../../routes/routes';
@@ -20,9 +20,9 @@ export interface CalculationPanelProp {
 }
 
 export function CalculationPanel({ answers, questions, onQuestionAnswered }: CalculationPanelProp): JSX.Element {
-	const seconds: RefObject<number> = useRef(0);
+	const secondsRef = useRef(0);
 	const handleTick = useCallback((nextSecond: number) => {
-		seconds.current = nextSecond;
+		secondsRef.current = nextSecond;
 	}, []);
 
 	const currentQuestionIndex: number = answers.length;
@@ -38,7 +38,7 @@ export function CalculationPanel({ answers, questions, onQuestionAnswered }: Cal
 			question: currentQuestion,
 			isCorrect: QuestionService.getAnswer(currentQuestion.expression) === answer,
 			answer: answer,
-			time: seconds.current
+			time: secondsRef.current
 		};
 
 		onQuestionAnswered(result);

--- a/src/components/CalculationPanel/Timer/Timer.module.css
+++ b/src/components/CalculationPanel/Timer/Timer.module.css
@@ -1,0 +1,12 @@
+.timer {
+	grid-area: timer;
+	display: flex;
+	flex-direction: row;
+	justify-content: center;
+	gap: 0.5rem;
+	font-weight: 500;
+
+	.time {
+		font-variant-numeric: tabular-nums;
+	}
+}

--- a/src/components/CalculationPanel/Timer/Timer.tsx
+++ b/src/components/CalculationPanel/Timer/Timer.tsx
@@ -1,0 +1,31 @@
+import { type JSX, useEffect, useState } from 'react';
+
+import styles from './Timer.module.css';
+
+export interface TimerProp {
+	onTick: (second: number) => void;
+}
+
+export function Timer({ onTick }: TimerProp): JSX.Element {
+	const [seconds, setSeconds] = useState<number>(0);
+
+	useEffect(() => {
+		const interval: number = setInterval(() => {
+			setSeconds(prev => prev + 1);
+		}, 1000);
+
+		return () => {
+			clearInterval(interval);
+		};
+	}, []);
+
+	useEffect(() => {
+		onTick(seconds);
+	}, [seconds, onTick]);
+
+	return (
+		<div className={styles.timer}>
+			<p className={styles.time}>Time: {seconds} Seconds</p>
+		</div>
+	);
+}


### PR DESCRIPTION
### Problem

The timer lived inside CalculationPanel, causing the entire panel to re-render every second and making it difficult to capture elapsed time without triggering constant renders.

### Solution

Moved the ticking state into a dedicated Timer component and fed the current seconds to CalculationPanel via a callback, storing it in a ref so it can be read when answering questions without re-rendering the panel.

### File Changes
File | Description
-- | --
CalculationPanel.tsx | Removed internal timer state/interval, added Timer component, and stored seconds in a ref for onQuestionAnswered.
CalculationPanel.module.css | Removed timer-specific styles (moved to Timer module).
Timer.tsx | Added timer component with its own interval and onTick callback.
Timer.module.css | Added timer-specific styles for layout and numeric display.

