### PR TITLE
Add Tool Tip

### DIFF
--- a/src/components/Share/ToolTip/ToolTip.module.css
+++ b/src/components/Share/ToolTip/ToolTip.module.css
@@ -1,0 +1,27 @@
+.wrapper {
+	position: relative;
+	display: inline-flex;
+
+	.tooltip {
+		position: absolute;
+		bottom: calc(100% + 1rem);
+		left: 50%;
+		transform: translate(-50%, 4px);
+		opacity: 0;
+		pointer-events: none;
+		transition: opacity 120ms ease, transform 120ms ease;
+		background: var(--color-surface-light);
+		color: var(--color-text-primary);
+		border-radius: 5px;
+		padding: 0.25rem 0.5rem;
+		font-size: var(--font-size-sm);
+		white-space: nowrap;
+		z-index: 10;
+	}
+
+	&:hover .tooltip,
+	&:focus-within .tooltip {
+		opacity: 1;
+		transform: translate(-50%, 0);
+	}
+}

--- a/src/components/Share/ToolTip/ToolTip.tsx
+++ b/src/components/Share/ToolTip/ToolTip.tsx
@@ -1,0 +1,18 @@
+import type { JSX, ReactNode} from "react";
+
+import classes from './ToolTip.module.css';
+
+export interface ToolTipProps
+{
+	content: string;
+	children: ReactNode;
+}
+export function ToolTip({content, children}: ToolTipProps): JSX.Element
+{
+	return (
+		<div className={classes.wrapper}>
+			<div>{children}</div>
+			<div role="tooltip" className={classes.tooltip}>{content}</div>
+		</div>
+	);
+}

--- a/src/shared/styles/theme.dark.css
+++ b/src/shared/styles/theme.dark.css
@@ -10,6 +10,7 @@
 	/* Surfaces colors */
 	--color-background: #181818;
 	--color-surface: #1d1b1b;
+	--color-surface-light: #404040;
 
 	/* Text colors */
 	--color-text-primary: #ffffffde;


### PR DESCRIPTION
### Summary
Add a reusable ToolTip component with hover/focus reveal styling.
Introduce a light surface token for tooltip backgrounds in dark theme.

### Why
Provide a consistent way to show small hover labels (e.g., badges or toggle buttons) without ad‑hoc styles.

### How
Add a ToolTip wrapper component that renders content and tooltip in `ToolTip.tsx`.
Define tooltip positioning and reveal behavior in `ToolTip.module.css`.
Add --color-surface-light to the dark theme in `theme.dark.css`.

### Changes
File | Changes
-- | --
src/components/Share/ToolTip/ToolTip.tsx | Add ToolTip wrapper component that renders tooltip content and children.
src/components/Share/ToolTip/ToolTip.module.css | Add tooltip positioning, reveal on hover/focus, and visual styling.
src/shared/styles/theme.dark.css | Add --color-surface-light for tooltip background color.

