### PR TITLE
Remove negative number

### DIFF
--- a/.codex/skills/draft-pr/SKILL.md
+++ b/.codex/skills/draft-pr/SKILL.md
@@ -41,3 +41,6 @@ When invoked, do the following:
 - Keep it readable and scannable.
 - Keep it github markdown friendly
 - Should be able to copy and paste to github PR with minimal edit
+- Never use markdown links for file names (avoid `[...]()` links, especially `file+.vscode-resource...`).
+- If a `file+.vscode-resource...` URL would appear in output, remove the URL entirely and keep only the visible text wrapped in backticks.
+- When highlighting file names, wrap them in backticks (e.g., `version.json`).

--- a/.codex/skills/update-version/SKILL.md
+++ b/.codex/skills/update-version/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: update-version
+description: Update `version.json` for release notes. Use when adding a new version entry or appending changes to the latest version. Follow the structure in `docs/Version/version.template.json`, keep versions ordered by date descending (newest first), and prompt the user to choose between creating a new version or updating the current latest version.
+---
+
+# Update Version
+
+## Workflow
+
+1. Open `version.json` and `docs/Version/version.template.json`.
+2. Ask the user which task to perform: add a new version entry (new release) or update the latest version (append changes).
+
+## Add A New Version Entry
+
+1. Use the object shape from `docs/Version/version.template.json` as the template.
+2. Ask the user for these fields:
+
+- `version` (semver string)
+- `date` (YYYY-MM-DD)
+- `title` (short release title)
+- `overview` (1–2 sentence summary)
+- `changes` list items: `type`, `scope`, `text`
+
+3. Insert the new version object at the top of `versions` (date-desc order).
+4. Preserve existing `meta` and other versions unchanged.
+
+## Update The Latest Version
+
+1. Identify the first entry in `versions` (newest).
+2. Ask the user for the list of changes to add.
+3. Append the new change objects to the end of the latest version’s `changes` array.
+4. Keep all other fields unchanged.
+
+## Output Rules
+
+- Only edit `version.json`.
+- Preserve formatting style (tabs/spacing) already used in the file.
+- Do not reorder or mutate existing change items except for the new additions.

--- a/docs/Version/version.template.json
+++ b/docs/Version/version.template.json
@@ -1,0 +1,22 @@
+{
+	"meta": {
+		"versioning": "semver",
+		"types": ["added", "changed", "fixed", "removed"],
+		"scopes": ["gameplay", "ui", "performance", "bug"]
+	},
+	"versions": [
+		{
+			"version": "1.0.1",
+			"date": "2026-02-06",
+			"title": "Removed negative subtraction results",
+			"overview": "Subtraction no longer generates negative answers.",
+			"changes": [
+				{
+					"type": "changed",
+					"scope": "gameplay",
+					"text": "Subtraction now clamps to non-negative results."
+				}
+			]
+		}
+	]
+}

--- a/docs/developer.journal.md
+++ b/docs/developer.journal.md
@@ -1,5 +1,10 @@
 # Developer Journal
 
+### Feb 6, 2026
+- Update random question generator only generate non zero subtraction question. I believe this would remove the edge cause of
+not having "-" key in mobile keyboard
+- Added version.json and skill in preparation for upcoming version page
+
 ### Jan 18, 2026
 
 - Updated logic to retrieve streak

--- a/src/shared/services/GeneratedQuestionService.ts
+++ b/src/shared/services/GeneratedQuestionService.ts
@@ -7,18 +7,12 @@ class GeneratedQuestionService extends RetrieveQuestionService {
 	private maxDigits: number = 2;
 	private maxQuestionCount: number = 9;
 	private minQuestionCount: number = 6;
-	private operatorSymbols: Map<Operation, string> = new Map<Operation, string>([
-		[Operation.Add, '+'],
-		[Operation.Subtract, '-'],
-		[Operation.Multiply, 'x']
-	]);
+	private availableOperations: Operation[] = [Operation.Add, Operation.Subtract, Operation.Multiply];
 
 	public async getQuestion(selectedOperations: Operation): Promise<Question[] | null> {
 		const questionCount = this.randomNumber(this.minQuestionCount, this.maxQuestionCount);
 		const questions: Question[] = [];
-		const operations: Operation[] = Array.from(this.operatorSymbols.keys()).filter(
-			(op) => (selectedOperations & op) !== 0
-		);
+		const operations: Operation[] = this.availableOperations.filter((op) => (selectedOperations & op) !== 0);
 
 		let id: number = 0;
 		while (questions.length < questionCount) {
@@ -29,10 +23,11 @@ class GeneratedQuestionService extends RetrieveQuestionService {
 			const num2: number = Math.floor(multiplier2 * Math.random());
 
 			const randomOperation: Operation = operations[this.randomNumber(0, operations.length - 1)];
-			const operator: string | undefined = this.operatorSymbols.get(randomOperation);
 
-			if (operator != undefined) {
-				questions.push(QuestionService.getQuestion(id.toString(), num1, num2, operator));
+			if (randomOperation == Operation.Subtract && num1 < num2) {
+				questions.push(QuestionService.getQuestion(id.toString(), num2, num1, randomOperation));
+			} else {
+				questions.push(QuestionService.getQuestion(id.toString(), num1, num2, randomOperation));
 			}
 		}
 

--- a/src/shared/services/QuestionService.ts
+++ b/src/shared/services/QuestionService.ts
@@ -1,4 +1,4 @@
-import type { Question } from '../../assets/types';
+import { Operation, type Question } from '../../assets/types';
 
 class QuestionService {
 	// Define operators and their operations
@@ -7,6 +7,12 @@ class QuestionService {
 		['-', (a, b) => a - b],
 		['x', (a, b) => a * b],
 		['/', (a, b) => a / b]
+	]);
+
+	private static operatorSymbolMap: Map<Operation, string> = new Map<Operation, string>([
+		[Operation.Add, '+'],
+		[Operation.Subtract, '-'],
+		[Operation.Multiply, 'x']
 	]);
 
 	public static getAnswer(expression: string): number {
@@ -19,24 +25,30 @@ class QuestionService {
 		}
 
 		const [, num1Str, operator, num2Str] = match;
-		const operation = this.operatorMap.get(operator);
+		const equation = this.operatorMap.get(operator);
 
-		if (!operation) {
+		if (!equation) {
 			throw new Error('Invalid operator');
 		}
 
-		return operation(Number(num1Str), Number(num2Str));
+		return equation(Number(num1Str), Number(num2Str));
 	}
 
-	public static getQuestion(id: string, num1: number, num2: number, operator: string): Question {
-		const fn = this.operatorMap.get(operator);
+	public static getQuestion(id: string, num1: number, num2: number, operator: Operation): Question {
+		const symbol = this.operatorSymbolMap.get(operator);
+
+		if (!symbol) {
+			throw new Error('Invalid operator');
+		}
+
+		const fn = this.operatorMap.get(symbol);
 
 		if (!fn) {
 			throw new Error('Invalid operator');
 		}
 
 		return {
-			expression: this.getExpression(num1, num2, operator),
+			expression: this.getExpression(num1, num2, symbol),
 			id: id
 		};
 	}

--- a/src/shared/services/UserActivityService/LocalStorageUserActivityService.ts
+++ b/src/shared/services/UserActivityService/LocalStorageUserActivityService.ts
@@ -5,7 +5,6 @@ import LocalStorageService from '../LocalStorageService';
 import UserActivityService, { type UserActivitiesResult, type UserActivityResult } from './UserActivityService';
 
 class LocalStorageUserActivityService extends UserActivityService {
-
 	constructor() {
 		super();
 	}
@@ -49,7 +48,6 @@ class LocalStorageUserActivityService extends UserActivityService {
 		const newCount: number = userActivity.count + 1;
 
 		if (LocalStorageService.setItem<number>(userActivity.date, newCount) != undefined) {
-			
 			const newUserActivity: UserActivity = { date: userActivity.date, count: newCount };
 			const userActivityResult: UserActivityResult = {
 				userActivity: newUserActivity,

--- a/version.json
+++ b/version.json
@@ -1,0 +1,22 @@
+{
+	"meta": {
+		"versioning": "semver",
+		"types": ["added", "changed", "fixed", "removed"],
+		"scopes": ["gameplay", "ui", "performance", "bug"]
+	},
+	"versions": [
+		{
+			"version": "1.0.1",
+			"date": "2026-02-06",
+			"title": "Removed negative subtraction results",
+			"overview": "Subtraction no longer generates negative answers.",
+			"changes": [
+				{
+					"type": "changed",
+					"scope": "gameplay",
+					"text": "Subtraction now clamps to non-negative results."
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
## Summary
Prevent subtraction questions from generating negative answers by swapping operands when needed.
Refactor question creation to pass Operation and map to symbols inside QuestionService.
Add release-notes scaffolding via `version.json`, `version.template.json`, and `SKILL.md`.

## Why
Reduce friction on mobile where typing - can be awkward (and avoid negative-answer edge cases).
Establish a consistent structure for upcoming version / release-notes work.

## How
Update subtraction generation in `GeneratedQuestionService.ts` to swap num1 / num2 for subtraction when num1 < num2.
Centralize Operation → symbol mapping in `QuestionService.ts` so callers don’t pass raw operator strings.
Add initial versioning template + entry in `version.template.json` and version.json, plus workflow guidance in `SKILL.md` and a brief note in `developer.journal.md`.