### PR TITLE
Make side menu mobile-friendly and refine layout styling

### DIFF
--- a/src/components/GameLayout/GameLayout.module.css
+++ b/src/components/GameLayout/GameLayout.module.css
@@ -1,11 +1,25 @@
 .game_layout {
 	min-height: 100svh;
 	width: 100%;
+	min-width: var(--bp-xs);
 	display: grid;
 	grid-template-columns: var(--sidebar_width) 1fr;
 
+	@media (max-width: 765px)
+	{
+		grid-template-columns: 1fr;
+		grid-template-rows: 1fr auto;
+
+		.content_container {
+			grid-row: 1 / 2;
+		}
+
+		.side_menu {
+			grid-row: 2 / 3;
+		}
+	}
+
 	.content_container {
-		min-height: 1svh;
 		display: flex;
 		align-items: center;
 		justify-content: center;

--- a/src/components/GameLayout/GameLayout.module.css
+++ b/src/components/GameLayout/GameLayout.module.css
@@ -5,8 +5,7 @@
 	display: grid;
 	grid-template-columns: var(--sidebar_width) 1fr;
 
-	@media (max-width: 765px)
-	{
+	@media (max-width: 765px) {
 		grid-template-columns: 1fr;
 		grid-template-rows: 1fr auto;
 

--- a/src/components/IntroPanel/ActivityHeatmap/ActivityHeatmap.module.css
+++ b/src/components/IntroPanel/ActivityHeatmap/ActivityHeatmap.module.css
@@ -26,7 +26,7 @@
 		background-color: var(--color-surface);
 
 		.heatmap_content {
-			max-width: 25rem;
+			max-width: 20rem;
 			display: grid;
 			overflow: auto;
 			margin: 0.5rem;
@@ -34,6 +34,11 @@
 				'.		month_header'
 				'day_header	heatmap';
 			column-gap: var(--grid_gap);
+
+			@media (min-width: 480px)
+			{
+				max-width: 30rem;
+			}
 
 			@media (min-width: 768px) {
 				max-width: 45rem;

--- a/src/components/IntroPanel/ActivityHeatmap/ActivityHeatmap.module.css
+++ b/src/components/IntroPanel/ActivityHeatmap/ActivityHeatmap.module.css
@@ -35,8 +35,7 @@
 				'day_header	heatmap';
 			column-gap: var(--grid_gap);
 
-			@media (min-width: 480px)
-			{
+			@media (min-width: 480px) {
 				max-width: 30rem;
 			}
 

--- a/src/components/IntroPanel/IntroPanel.module.css
+++ b/src/components/IntroPanel/IntroPanel.module.css
@@ -4,7 +4,7 @@
 	width: fit-content;
 	align-items: center;
 	gap: 1.5rem;
-	
+
 	.instruction {
 		margin-top: 0.5rem;
 	}

--- a/src/components/IntroPanel/IntroPanel.module.css
+++ b/src/components/IntroPanel/IntroPanel.module.css
@@ -4,7 +4,7 @@
 	width: fit-content;
 	align-items: center;
 	gap: 1.5rem;
-
+	
 	.instruction {
 		margin-top: 0.5rem;
 	}

--- a/src/components/Share/SideMenu/SideMenu.module.css
+++ b/src/components/Share/SideMenu/SideMenu.module.css
@@ -1,33 +1,66 @@
 .side_menu {
-	position: sticky;
-	top: 0;
-	height: 100svh;
-	z-index: 10;
-
-	&:hover,
-	&:focus-within {
+	
+	/* desktop view */
+	@media (min-width: 766px)
+	{
+		position: sticky;
+		top: 0;
+		height: 100svh;
+		z-index: 10;
+	
+		&:hover,
+		&:focus-within {
+			.side_menu_label_expander {
+				width: 12rem;
+				overflow: visible;
+			}
+		}
+	
 		.side_menu_label_expander {
-			width: 12rem;
-			overflow: visible;
+			width: var(--sidebar_width);
+			height: 100%;
+			overflow: hidden;
+			transition: width 180ms;
+	
+			.side_menu_container {
+				display: flex;
+				flex-direction: column;
+				align-items: start;
+				justify-content: center;
+				gap: 1rem;
+				height: 100%;
+				background-color: var(--color-background);
+				pointer-events: auto;
+				padding-left: 0.5rem;
+			}
 		}
 	}
 
-	.side_menu_label_expander {
-		width: var(--sidebar_width);
-		height: 100%;
-		overflow: hidden;
-		transition: width 180ms;
-
-		.side_menu_container {
-			display: flex;
-			flex-direction: column;
-			align-items: start;
-			justify-content: center;
-			gap: 1rem;
+	/* mobile view */
+	@media (max-width: 765px) {
+		position: fixed;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		width: 100%;
+		z-index: 20;
+		border-top: 1px solid var(--color-border-muted-l);
+		
+		.side_menu_label_expander {
+			width: 100%;
 			height: 100%;
-			background-color: var(--color-background);
-			pointer-events: auto;
-			padding-left: 0.5rem;
+	
+			.side_menu_container {
+				display: flex;
+				flex-direction: row;
+				justify-content: center;
+				align-items: center;
+				height: 100%;
+				background-color: var(--color-background);
+				pointer-events: auto;
+				padding: 0.75rem 1rem;
+				gap: 1.5rem;
+			}
 		}
 	}
 }

--- a/src/components/Share/SideMenu/SideMenu.module.css
+++ b/src/components/Share/SideMenu/SideMenu.module.css
@@ -1,13 +1,11 @@
 .side_menu {
-	
 	/* desktop view */
-	@media (min-width: 766px)
-	{
+	@media (min-width: 766px) {
 		position: sticky;
 		top: 0;
 		height: 100svh;
 		z-index: 10;
-	
+
 		&:hover,
 		&:focus-within {
 			.side_menu_label_expander {
@@ -15,13 +13,13 @@
 				overflow: visible;
 			}
 		}
-	
+
 		.side_menu_label_expander {
 			width: var(--sidebar_width);
 			height: 100%;
 			overflow: hidden;
 			transition: width 180ms;
-	
+
 			.side_menu_container {
 				display: flex;
 				flex-direction: column;
@@ -45,11 +43,11 @@
 		width: 100%;
 		z-index: 20;
 		border-top: 1px solid var(--color-border-muted-l);
-		
+
 		.side_menu_label_expander {
 			width: 100%;
 			height: 100%;
-	
+
 			.side_menu_container {
 				display: flex;
 				flex-direction: row;

--- a/src/components/Share/SideMenu/SideMenu.tsx
+++ b/src/components/Share/SideMenu/SideMenu.tsx
@@ -16,7 +16,7 @@ import classes from './SideMenu.module.css';
 export function SideMenu(): JSX.Element {
 	
 	const navigate: NavigateFunction = useNavigate();
-	const iconSize: number = 24;
+	const iconSize: number = 28;
 	const noop = (): void => {};
 
 	return (

--- a/src/components/Share/SideMenu/SideMenu.tsx
+++ b/src/components/Share/SideMenu/SideMenu.tsx
@@ -1,4 +1,4 @@
-import { type NavigateFunction,useNavigate } from 'react-router-dom';
+import { type NavigateFunction, useNavigate } from 'react-router-dom';
 
 import type { JSX } from 'react';
 
@@ -14,7 +14,6 @@ import { SideMenuButton } from './SideMenuButton/SideMenuButton';
 import classes from './SideMenu.module.css';
 
 export function SideMenu(): JSX.Element {
-	
 	const navigate: NavigateFunction = useNavigate();
 	const iconSize: number = 28;
 	const noop = (): void => {};
@@ -23,19 +22,19 @@ export function SideMenu(): JSX.Element {
 		<aside className={classes.side_menu}>
 			<div className={classes.side_menu_label_expander}>
 				<div className={classes.side_menu_container}>
-					<SideMenuButton label='Home' onClicked={() => navigate(paths.home)}>
+					<SideMenuButton label="Home" onClicked={() => navigate(paths.home)}>
 						<img width={iconSize} height={iconSize} src={homeIcon} alt="Home" />
 					</SideMenuButton>
-					<SideMenuButton label='Settings' onClicked={noop}>
+					<SideMenuButton label="Settings" onClicked={noop}>
 						<img width={iconSize} height={iconSize} src={settingsIcon} alt="Settings" />
 					</SideMenuButton>
-					<SideMenuButton label='Updates' onClicked={noop}>
+					<SideMenuButton label="Updates" onClicked={noop}>
 						<img width={iconSize} height={iconSize} src={updatesIcon} alt="Updates" />
 					</SideMenuButton>
-					<SideMenuButton label='About Me' onClicked={noop}>
+					<SideMenuButton label="About Me" onClicked={noop}>
 						<img width={iconSize} height={iconSize} src={aboutMeIcon} alt="About Me" />
 					</SideMenuButton>
-					<SideMenuButton label='Contact' onClicked={noop}>
+					<SideMenuButton label="Contact" onClicked={noop}>
 						<img width={iconSize} height={iconSize} src={contactIcon} alt="Contact" />
 					</SideMenuButton>
 				</div>

--- a/src/components/Share/SideMenu/SideMenuButton/SideMenuButton.module.css
+++ b/src/components/Share/SideMenu/SideMenuButton/SideMenuButton.module.css
@@ -19,7 +19,7 @@
 	&:focus,
 	&:focus-visible {
 		outline: none;
-		background-color: var(--color-background);
+		background-color: var(--color-hover);
 	}
 
 	.side_menu_button_label {

--- a/src/components/Share/SideMenu/SideMenuButton/SideMenuButton.module.css
+++ b/src/components/Share/SideMenu/SideMenuButton/SideMenuButton.module.css
@@ -1,6 +1,6 @@
 .side_menu_button {
 	--menu_item_icon_height: 50px;
-	
+
 	padding: 4px;
 	width: 2.5rem;
 	height: 2.5rem;
@@ -9,16 +9,15 @@
 	align-items: center;
 	justify-content: center;
 	background: var(--color-background);
-	
+
 	&:active {
 		transform: scale(0.97);
 		background-color: var(--color-hover);
 	}
-	
+
 	&:hover,
 	&:focus,
-	&:focus-visible
-	{
+	&:focus-visible {
 		outline: none;
 		background-color: var(--color-background);
 	}
@@ -26,9 +25,8 @@
 	.side_menu_button_label {
 		display: none;
 	}
-	
-	@media (min-width: 766px)
-	{
+
+	@media (min-width: 766px) {
 		display: grid;
 		grid-template-columns: 2.5rem 1fr;
 		min-height: var(--menu_item_icon_height);
@@ -46,8 +44,7 @@
 
 		&:hover,
 		&:focus,
-		&:focus-visible
-		{
+		&:focus-visible {
 			outline: none;
 			background-color: var(--color-hover);
 		}

--- a/src/components/Share/SideMenu/SideMenuButton/SideMenuButton.module.css
+++ b/src/components/Share/SideMenu/SideMenuButton/SideMenuButton.module.css
@@ -1,40 +1,64 @@
 .side_menu_button {
-	--menu_item_icon_height: 2rem;
-
-	display: grid;
-	grid-template-columns: var(--menu_item_icon_height) 1fr;
-	align-items: center;
-	min-height: var(--menu_item_icon_height);
-	gap: 0.5rem;
-	width: auto;
-	border-radius: 0.5rem;
-	padding: 0.5rem 1rem;
-	cursor: pointer;
-	user-select: none;
-	transform-origin: left center;
+	--menu_item_icon_height: 50px;
+	
+	padding: 4px;
+	width: 2.5rem;
+	height: 2.5rem;
 	border-width: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 	background: var(--color-background);
-	transition:
-		transform 120ms ease,
-		background-color 120ms ease;
-
+	
 	&:active {
 		transform: scale(0.97);
+		background-color: var(--color-hover);
 	}
-
+	
 	&:hover,
 	&:focus,
 	&:focus-visible
 	{
 		outline: none;
-		background-color: var(--color-hover);
+		background-color: var(--color-background);
 	}
 
 	.side_menu_button_label {
-		padding-top: 0;
-		font-size: var(--font-size-md);
-		font-weight: 500;
-		overflow: hidden;
-		white-space: nowrap;
+		display: none;
+	}
+	
+	@media (min-width: 766px)
+	{
+		display: grid;
+		grid-template-columns: 2.5rem 1fr;
+		min-height: var(--menu_item_icon_height);
+		gap: 0.5rem;
+		width: auto;
+		border-radius: 0.5rem;
+		padding: 0.5rem 1rem;
+		cursor: pointer;
+		user-select: none;
+		transform-origin: left center;
+		border-width: 0;
+		transition:
+			transform 120ms ease,
+			background-color 120ms ease;
+
+		&:hover,
+		&:focus,
+		&:focus-visible
+		{
+			outline: none;
+			background-color: var(--color-hover);
+		}
+
+		.side_menu_button_label {
+			display: block;
+			padding-top: 0;
+			font-size: var(--font-size-md);
+			font-weight: 600;
+			overflow: hidden;
+			white-space: nowrap;
+		}
 	}
 }

--- a/src/components/Share/SideMenu/SideMenuButton/SideMenuButton.tsx
+++ b/src/components/Share/SideMenu/SideMenuButton/SideMenuButton.tsx
@@ -3,14 +3,14 @@ import { type JSX, type ReactNode } from 'react';
 import classes from './SideMenuButton.module.css';
 
 export interface SideMenuButtonProps {
-	children: ReactNode,
-	label: string,
-	onClicked: () => void
+	children: ReactNode;
+	label: string;
+	onClicked: () => void;
 }
 
-export function SideMenuButton({children, label, onClicked}: SideMenuButtonProps): JSX.Element {
-  return (
-		<button className={classes.side_menu_button} onClick={onClicked} >
+export function SideMenuButton({ children, label, onClicked }: SideMenuButtonProps): JSX.Element {
+	return (
+		<button className={classes.side_menu_button} onClick={onClicked}>
 			{children}
 			<span className={classes.side_menu_button_label}>{label}</span>
 		</button>

--- a/src/index.css
+++ b/src/index.css
@@ -50,6 +50,7 @@ button {
 	font-size: var(--font-size-md);
 	font-weight: 500;
 	font-family: inherit;
+	color: var(--color-text-primary);
 	background-color: var(--color-surface);
 	cursor: pointer;
 	transition: border-color 0.25s;

--- a/src/shared/styles/theme.dark.css
+++ b/src/shared/styles/theme.dark.css
@@ -23,6 +23,7 @@
 	/* Border colors */
 	--color-border: #e6e6e6;
 	--color-border-muted: #8d918b;
+	--color-border-muted-l: #626662;
 
 	/* Interactive colors  */
 	--color-focus: #ffffff;

--- a/src/shared/styles/tokens.css
+++ b/src/shared/styles/tokens.css
@@ -13,7 +13,7 @@
 	--border-radius: 0.5rem;
 
 	/* Screen Sizes */
-	--bp-xs: 0px;
+	--bp-xs: 360px;
 	--bp-s: 480px;
 	--bp-md: 768px;
 	--bp-lg: 1024px;

--- a/src/test/GameLayout.SideMenu.ShowsButtons.integration.test.tsx
+++ b/src/test/GameLayout.SideMenu.ShowsButtons.integration.test.tsx
@@ -1,12 +1,11 @@
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from 'react-router-dom';
 
-import { render, screen, within } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
 
-import App from "../App";
+import App from '../App';
 
-describe('Side menu buttons should be displaying in Game Layout', () =>
-{
+describe('Side menu buttons should be displaying in Game Layout', () => {
 	const menuButtons = [
 		{ label: /Home/i, iconAlt: /Home/i },
 		{ label: /Settings/i, iconAlt: /Settings/i },


### PR DESCRIPTION
### Summary
Add a mobile bottom-bar layout for the side menu with icon-only buttons and updated sizing.
Adjust layout/heatmap sizing for small screens and introduce a muted border token.
Normalize button text color and tighten test formatting.

### Why
Provide a usable navigation experience on mobile screens without shrinking core content.
Keep layout and styling consistent across breakpoints.

### How
Update SideMenu and button CSS modules to switch between desktop and mobile layouts via media queries.
Tweak GameLayout grid and ActivityHeatmap max widths for smaller devices.
Add styling tokens and default button text color in shared styles.